### PR TITLE
Add xUnit test project for OrderUtil

### DIFF
--- a/ECommerceApi.Tests/ECommerceApi.Tests.csproj
+++ b/ECommerceApi.Tests/ECommerceApi.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Test.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.6.5" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.6.5" />
+    <PackageReference Include="coverlet.collector" Version="6.0.3" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ECommerceApi\ECommerceApi.csproj" />
+  </ItemGroup>
+</Project>

--- a/ECommerceApi.Tests/GraphQL/Types/Orders/Util/OrderUtilTests.cs
+++ b/ECommerceApi.Tests/GraphQL/Types/Orders/Util/OrderUtilTests.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using ECommerceApi.Data;
+using ECommerceApi.GraphQL.Types.Orders.Util;
+using Xunit;
+
+namespace ECommerceApi.Tests.GraphQL.Types.Orders.Util
+{
+    public class OrderUtilTests
+    {
+        [Fact]
+        public void CalculateTotalPrice_SumsSubtotalPriceTimesQuantity()
+        {
+            // Arrange
+            var details = new List<OrderDetail>
+            {
+                new OrderDetail { Quantity = 2, SubtotalPrice = 10m },
+                new OrderDetail { Quantity = 3, SubtotalPrice = 5m },
+                new OrderDetail { Quantity = 1, SubtotalPrice = 20m }
+            };
+
+            // Act
+            var result = OrderUtil.CalculateTotalPrice(details);
+
+            // Assert
+            var expected = 2 * 10m + 3 * 5m + 1 * 20m;
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/ECommerceApi.sln
+++ b/ECommerceApi.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.9.34728.123
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ECommerceApi", "ECommerceApi\ECommerceApi.csproj", "{6A5056D5-1D65-4CAB-B04D-B325C1DE9453}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ECommerceApi.Tests", "ECommerceApi.Tests\ECommerceApi.Tests.csproj", "{2390B4FF-90D7-4062-AF4E-B3035A2554AC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -12,10 +14,14 @@ Global
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{6A5056D5-1D65-4CAB-B04D-B325C1DE9453}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6A5056D5-1D65-4CAB-B04D-B325C1DE9453}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6A5056D5-1D65-4CAB-B04D-B325C1DE9453}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6A5056D5-1D65-4CAB-B04D-B325C1DE9453}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {6A5056D5-1D65-4CAB-B04D-B325C1DE9453}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {6A5056D5-1D65-4CAB-B04D-B325C1DE9453}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {6A5056D5-1D65-4CAB-B04D-B325C1DE9453}.Release|Any CPU.Build.0 = Release|Any CPU
+                {2390B4FF-90D7-4062-AF4E-B3035A2554AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {2390B4FF-90D7-4062-AF4E-B3035A2554AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {2390B4FF-90D7-4062-AF4E-B3035A2554AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {2390B4FF-90D7-4062-AF4E-B3035A2554AC}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/README.md
+++ b/README.md
@@ -139,8 +139,11 @@
               }
             </code>
            </div>
-         </li>
+        </li>
       </ul>
+
+      <h1 class="title">Running tests</h1>
+      <p>Use the <code>dotnet test</code> command from the repository root to execute the unit tests. The tests are contained in the <code>ECommerceApi.Tests</code> project.</p>
 
   </body>
   <footer>


### PR DESCRIPTION
## Summary
- add xUnit based `ECommerceApi.Tests` project
- test `OrderUtil.CalculateTotalPrice`
- register the new test project in the solution
- document test execution in README

## Testing
- `dotnet test ECommerceApi.sln` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406b95e5208326a68faaf7cd6190a2